### PR TITLE
Update Travis CI to run python 3.8 so that the sanity tests are not skipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
-
-devops
-.travis.yml
+playbooks/*issue*
 .DS_Store
 .vscode
-venv
+venv*
 tests/output
 hosts
+.*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ sudo: required
 dist: bionic
 language: python
 python:
-  - "3.7"
+  - "3.8"
 
 # command to install dependencies
 install:
   - sudo add-apt-repository ppa:deadsnakes/ppa --yes
   - sudo apt-get --yes --force-yes install python3-venv
-  - pip install ansible==2.9
+  - pip install ansible==2.9.*
   - pip install flake8
   - pip3 install ansible-doc-extractor
   - pip install sphinx
@@ -28,10 +28,6 @@ script:
   #  E402: <module> level import not at top of file (as per Ansible module developement)
   #  W503: line break before binary operator (PEP8 advices to put logical operator ahead)
   - flake8 plugins/modules/* --max-line-length=160 --ignore=E402,W503
-
-  # checking yaml syntax is not relevant since there are just examples.
-  #- ansible-playbook playbook_aix_flrtvc.yml --syntax-check
-  #- ansible-playbook playbook_aix_suma_targets_all.yml --syntax-check
 
   - bash devops/bin/sanity_test.sh
   - bash devops/bin/gen_doc.sh

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,102 @@
-PYTHON_VERSION := $(shell python -c "import sys; print('%d.%d' % sys.version_info[0:2])")
+ifndef PYTHON_VERSION
+	PYTHON_VERSION := $(shell python -c "import sys; print('%d.%d' % sys.version_info[0:2])")
+endif
+
+ifndef MODULE
+	MODULE = plugins/modules/*.py
+endif
+
+ifndef TEST
+	TEST = tests/unit/plugins/modules/*.py
+endif
+
+DEPRECATED = plugins/modules/_*.py
+TEST_OMIT = $(DEPRECATED),tests/*
+
+######################################################################################
+# utility targets
+######################################################################################
 
 .PHONY: help
 help:
 	@echo "usage: make <target>"
 	@echo ""
 	@echo "target:"
-	@echo "clean					clean junk files"
-	@echo "lint					lint module"         
-	@echo "install-unit-test-requirements 		install python modules needed run unit testing"
-	@echo "unit-test 				run unit test suite for the collection"
+	@echo "install-requirements ANSIBLE_VERSION=<version> 	install all requirements"
+	@echo "install-ansible ANSIBLE_VERSION=<version>	install ansible: 2.9, 3, or 4"
+	@echo "install-ansible-devel-branch			install ansible development branch"
+	@echo "install-sanity-test-requirements		install python modules needed to \
+	run sanity testing"
+	@echo "install-unit-test-requirements 			install python modules needed \
+	run unit testing"
+	@echo "lint [MODULE]					lint module"         
+	@echo "sanity-test [MODULE]				run sanity test on the collections"
+	@echo "unit-test [TEST]				run unit test suite for the collection"
+	@echo "clean						clean junk files"
 
-.PHONY: lint
-lint:
-ifdef MODULE
-	flake8 $(MODULE) --max-line-length=160 --ignore=E402,W503
-	python -m pycodestyle --max-line-length=160 --ignore=E402,W503 $(MODULE)
-	ansible-test sanity --test pep8 "$(MODULE)"
+.PHONY: clean
+clean:
+	@rm -rf tests/unit/plugins/modules/__pycache__
+	@rm -rf tests/unit/plugins/modules/common/__pycache__
+	@rm -rf collections/ansible_collections
+	@rm -rf plugins/modules/__pycache__
+
+######################################################################################
+# installation targets
+######################################################################################
+
+.PHONY: install-requirements
+install-requirements: install-ansible install-sanity-test-requirements \
+		install-unit-test-requirements
+	python -m pip install --upgrade pip
+
+.PHONY: install-ansible
+install-ansible:
+	python -m pip install --upgrade pip
+ifdef ANSIBLE_VERSION
+	python -m pip install ansible==$(ANSIBLE_VERSION).*
 else
-	flake8 plugins/modules/* --max-line-length=160 --ignore=E402,W503
-	python -m pycodestyle --max-line-length=160 --ignore=E402,W503 plugins/modules/*
-	ansible-test sanity --test pep8 "plugins/modules/*"
+	python -m pip install ansible
 endif
+
+.PHONY: install-ansible-devel-branch
+install-ansible-devel-branch:
+	python -m pip install --upgrade pip
+	python -m pip install https://github.com/ansible/ansible/archive/devel.tar.gz \
+	--disable-pip-version-check
+
+.PHONY: install-sanity-test-requirements
+install-sanity-test-requirements:
+	python -m pip install -r tests/sanity/sanity.requirements
 
 .PHONY: install-unit-test-requirements
 install-unit-test-requirements:
 	python -m pip install -r tests/unit/unit.requirements
+
+######################################################################################
+# testing targets
+######################################################################################
+
+.PHONY: lint
+lint:
+	flake8 $(MODULE)
+	python -m pycodestyle $(MODULE)
+	ansible-test sanity --test pep8 --python $(PYTHON_VERSION) \
+	--exclude $(DEPRECATED) $(MODULE)
+
+.PHONY: sanity-test
+sanity-test:
+	ansible-test sanity -v --color yes --truncate 0 --python $(PYTHON_VERSION) \
+	--exclude $(DEPRECATED) $(MODULE)
 
 .PHONY: unit-test
 unit-test:
 	@if [ -d "tests/output/coverage" ]; then \
 		ansible-test coverage erase; \
 	fi
-	ansible-test units -v --python $(PYTHON_VERSION)  --coverage
-	ansible-test coverage report --include 'plugins/modules/*' --show-missing
+	ansible-test units -v --color yes --python $(PYTHON_VERSION) \
+	--coverage $(TEST)
+	
+	ansible-test coverage report --omit $(TEST_OMIT) --include "$(MODULE)" --show-missing
 
-.PHONY: clean
-clean:
-	@rm -rf tests/output
-	@rm -rf tests/unit/plugins/modules/__pycache__
-	@rm -rf tests/unit/plugins/modules/common/__pycache__
+

--- a/devops/bin/sanity_test.sh
+++ b/devops/bin/sanity_test.sh
@@ -7,7 +7,7 @@ set -o pipefail
 set -o errtrace
 
 OUTPUTDIR=./documentation
-PY_VERSIONS="2.7 3.7"
+PY_VERSIONS="3.8"
 
 err_report() {
     echo "Error running '$1' [rc=$2] line $3 "

--- a/plugins/modules/_nim_upgradeios.py
+++ b/plugins/modules/_nim_upgradeios.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 ---
 author:
 - AIX Development Team (@pbfinley1911)
-module: _nim_upgradeios
+module: nim_upgradeios
 short_description: Use NIM to update a single or a pair of Virtual I/O Servers.
 description:
 - Uses the NIM to perform upgrade to Virtual I/O Server (VIOS) targets tuple.

--- a/plugins/modules/flrtvc.py
+++ b/plugins/modules/flrtvc.py
@@ -393,8 +393,8 @@ def unzip(src, dst, resize_fs=True):
         False otherwise
     """
     try:
-        zfile = zipfile.ZipFile(src)
-        zfile.extractall(dst)
+        with zipfile.ZipFile(src, "r") as zfile:
+            zfile.extractall(dst)
     except (zipfile.BadZipfile, zipfile.LargeZipFile, RuntimeError) as exc:
         if resize_fs and increase_fs(dst):
             return unzip(src, dst, resize_fs)
@@ -1000,38 +1000,43 @@ def run_downloader(urls, dst_path, resize_fs=True):
 
             # download and open tar file
             if download(url, dst, resize_fs):
-                tar = tarfile.open(dst, 'r')
+                with tarfile.open(dst, "r") as tar:
 
-                # find all epkg in tar file
-                epkgs = [epkg for epkg in tar.getnames() if re.search(r'(\b[\w.-]+.epkg.Z\b)$', epkg)]
-                out['2.discover'].extend(epkgs)
-                module.debug('found {0} epkg.Z file in tar file'.format(len(epkgs)))
+                    # find all epkg in tar file
+                    epkgs = [
+                        epkg for epkg in tar.getnames()
+                        if re.search(r'(\b[\w.-]+.epkg.Z\b)$', epkg)
+                    ]
+                    out['2.discover'].extend(epkgs)
+                    module.debug('found {0} epkg.Z file in tar file'.format(len(epkgs)))
 
-                # extract epkg
-                tar_dir = os.path.join(dst_path, 'tardir')
-                if not os.path.exists(tar_dir):
-                    os.makedirs(tar_dir)
-                for epkg in epkgs:
-                    for attempt in range(3):
-                        try:
-                            tar.extract(epkg, tar_dir)
-                        except (OSError, IOError, tarfile.TarError) as exc:
-                            if resize_fs:
-                                increase_fs(tar_dir)
+                    # extract epkg
+                    tar_dir = os.path.join(dst_path, 'tardir')
+                    if not os.path.exists(tar_dir):
+                        os.makedirs(tar_dir)
+                    for epkg in epkgs:
+                        for attempt in range(3):
+                            try:
+                                tar.extract(epkg, tar_dir)
+                            except (OSError, IOError, tarfile.TarError) as exc:
+                                if resize_fs:
+                                    increase_fs(tar_dir)
+                                else:
+                                    msg = 'Cannot extract tar file {0} to {1}'.format(
+                                        epkg, tar_dir
+                                    )
+                                    module.log(msg)
+                                    module.log('EXCEPTION {0}'.format(exc))
+                                    results['meta']['messages'].append(msg)
+                                    break
                             else:
-                                msg = 'Cannot extract tar file {0} to {1}'.format(epkg, tar_dir)
-                                module.log(msg)
-                                module.log('EXCEPTION {0}'.format(exc))
-                                results['meta']['messages'].append(msg)
                                 break
                         else:
-                            break
-                    else:
-                        msg = 'Cannot extract tar file {0} to {1}'.format(epkg, tar_dir)
-                        module.log(msg)
-                        results['meta']['messages'].append(msg)
-                        continue
-                    out['3.download'].append(os.path.abspath(os.path.join(tar_dir, epkg)))
+                            msg = 'Cannot extract tar file {0} to {1}'.format(epkg, tar_dir)
+                            module.log(msg)
+                            results['meta']['messages'].append(msg)
+                            continue
+                        out['3.download'].append(os.path.abspath(os.path.join(tar_dir, epkg)))
 
         else:  # URL as a Directory
             module.debug('treat url as a directory')

--- a/plugins/modules/lvol.py
+++ b/plugins/modules/lvol.py
@@ -80,7 +80,7 @@ options:
     - Specifies the number of logical partitions or the size of the
       the logical volume in terms of K, M, or G.
     - Can be used to create a logical volume, hence when I(state=present).
-    type: int
+    type: str
     default: 1
   pv_list:
     description:

--- a/plugins/modules/nim_suma.py
+++ b/plugins/modules/nim_suma.py
@@ -487,19 +487,18 @@ def find_sp_version(module, file):
     """
     sp_version = None
     module.debug("opening file: {0}".format(file))
-    myfile = open(file, "r")
-    for line in myfile:
-        # module.debug("line: {0}".format(line.rstrip()))
-        match_item = re.match(
-            r"^<SP name=\"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})\">$",
-            line.rstrip())
-        if match_item:
-            version = match_item.group(1)
-            module.debug("matched line: {0}, version={1}".format(line.rstrip(), version))
-            if sp_version is None or version > sp_version:
-                sp_version = version
-            break
-    myfile.close()
+    with open(file, "r") as myfile:
+        for line in myfile:
+            # module.debug("line: {0}".format(line.rstrip()))
+            match_item = re.match(
+                r"^<SP name=\"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})\">$",
+                line.rstrip())
+            if match_item:
+                version = match_item.group(1)
+                module.debug("matched line: {0}, version={1}".format(line.rstrip(), version))
+                if sp_version is None or version > sp_version:
+                    sp_version = version
+                break
 
     return sp_version
 

--- a/plugins/modules/nim_viosupgrade.py
+++ b/plugins/modules/nim_viosupgrade.py
@@ -793,11 +793,10 @@ def main():
     targets = []
     if module.params['target_file']:
         try:
-            myfile = open(module.params['target_file'], 'r')
-            csvreader = csv.reader(myfile, delimiter=':')
-            for line in csvreader:
-                targets.append(line[0].strip())
-            myfile.close()
+            with open(module.params['target_file'], 'r') as myfile:
+                csvreader = csv.reader(myfile, delimiter=':')
+                for line in csvreader:
+                    targets.append(line[0].strip())
         except IOError as e:
             msg = 'Failed to parse file {0}: {1}. Check the file content is '.format(e.filename, e.strerror)
             module.log(msg)

--- a/plugins/modules/suma.py
+++ b/plugins/modules/suma.py
@@ -258,19 +258,18 @@ def find_sp_version(file):
     """
     sp_version = None
     module.debug("opening file: {0}".format(file))
-    myfile = open(file, "r")
-    for line in myfile:
-        # module.debug("line: {0}".format(line.rstrip()))
-        match_item = re.match(
-            r"^<SP name=\"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})\">$",
-            line.rstrip())
-        if match_item:
-            version = match_item.group(1)
-            module.debug("matched line: {0}, version={1}".format(line.rstrip(), version))
-            if sp_version is None or version > sp_version:
-                sp_version = version
-            break
-    myfile.close()
+    with open(file, "r") as myfile:
+        for line in myfile:
+            # module.debug("line: {0}".format(line.rstrip()))
+            match_item = re.match(
+                r"^<SP name=\"([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4})\">$",
+                line.rstrip())
+            if match_item:
+                version = match_item.group(1)
+                module.debug("matched line: {0}, version={1}".format(line.rstrip(), version))
+                if sp_version is None or version > sp_version:
+                    sp_version = version
+                break
 
     return sp_version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+ignore = E402,W503
+max-line-length = 160
+exclude = plugins/modules/_*.py
+
+[pycodestyle]
+ignore = E402,W503
+max-line-length = 160
+exclude = plugins/modules/_*.py

--- a/tests/sanity/sanity.requirements
+++ b/tests/sanity/sanity.requirements
@@ -1,0 +1,6 @@
+pycodestyle
+pylint
+six
+voluptuous
+yamllint
+flake8


### PR DESCRIPTION
- ansible-test sanity is the command to run the built-in sanity tests of ansible on our collection
- currently, at least python 3.8 is needed to run ansible-test sanity properly. Our Travis CI config file
specifies python 3.7, this will result in sanity tests being skipped.
- this PR will correct this problem. Travis CI is now configured to have python 3.8 running on the test environment
- In addition to updating the python version used, the ansible version is also updated such that the latest
2.9.* version is used (NOT 2.10, 2.11, or 2.12).
- after running the sanity check, a few checks were hit and thus failed the test.This PR also includes the fixes to those
hit issues.
- Makefile now includes the targets: `lint` and `sanity-test` to run the pep8 linter or the sanity test
- To run the test properly so it coincides with the Travis CI sanity test, you would need to have python 3.8 installed in your system, and pip install ansible==2.9.* (if you do not specify the version, it will use a higher version of ansible. we should use 2.9.* as this is the lowest version we are supporting, the asterisk is for specifying to get the highest patch version, we want to have the latest patch on 2.9 at least as this fixes some issues in ansible that might cause us problems.)
- linting and sanity testing depends on some python modules, hence Makefile now has the target `install-sanity-test-requirements`
to install all the required python modules needed for linting and sanity testing.
- run `make help` on the root directory of the repo to see other targets
- updated the sanity_test.sh script to run the sanity test on python 3.8
- consequently, any compile test is done only on python 3.8. this guarantees at least that the collection complies with python 3.8 syntax.
- there are various files that are touched to fix the sanity checks