### PR TITLE
fixed NFS mount for when both mount_dir and mount_over_dir is used

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -115,8 +115,16 @@ EXAMPLES = r'''
 
 - name: Mount filesystems provided by a node"
   ibm.power_aix.mount:
-    node: aixbase.aus.stglabs.ibm.com
+    node: ansible-test1
     mount_dir: /mnt
+
+- name: |
+    Mount a filesytems, /tmp/servnfs provided by
+    a node on the mount point /tmp/clientnfs"
+  ibm.power_aix.mount:
+    node: ansible-test1
+    mount_dir: /tmp/servnfs
+    mount_over_dir: /tmp/clientnfs
 
 - name: Unmount remote filesystems
   ibm.power_aix.mount:
@@ -171,7 +179,11 @@ def is_fspath_mounted(module, mount_dir, mount_over_dir):
     """
     global result
 
-    if mount_dir:
+    if mount_dir and mount_over_dir:
+        # when mounting make sure NFS, we check for the NFS
+        # client mount point
+        cmd = "lsfs -l %s" % mount_over_dir
+    elif mount_dir:
         cmd = "lsfs -l %s" % mount_dir
     elif mount_over_dir:
         cmd = "lsfs -l %s" % mount_over_dir

--- a/tests/unit/plugins/modules/common/sample_df_output2
+++ b/tests/unit/plugins/modules/common/sample_df_output2
@@ -9,5 +9,5 @@ Filesystem    512-blocks      Free %Used    Iused %Iused Mounted on
 /dev/hd10opt     2621440   1050416   60%    10048     8% /opt
 /dev/livedump     524288    523552    1%        4     1% /var/adm/ras/livedump
 /ahafs                 -         -    -       35     1% /aha
-carribean-lp4:/tmp/lp4nfs      163840    163152    1%        4     1% /tmp/clientnfs
+ansible-test1:/tmp/servnfs      163840    163152    1%        4     1% /tmp/clientnfs
 

--- a/tests/unit/plugins/modules/common/sample_lsfs_output3
+++ b/tests/unit/plugins/modules/common/sample_lsfs_output3
@@ -1,2 +1,2 @@
 Name            Nodename   Mount Pt               VFS   Size    Options    Auto Accounting
-/tmp/lp4nfs     carribean-lp4 /tmp/clientnfs         nfs   --      intr       no   no
+/tmp/servnfs     ansible-test1 /tmp/clientnfs         nfs   --      intr       no   no


### PR DESCRIPTION
- fixed the following scenario for mount module
scenario: attempting to mount a remote FS, the parameters
mount_dir (mount point of the bacing FS form remote node)
and mount_over_dir (where to mount the backing FS on the
local node) are used, however checked is being done on
mount_dir instead mount_over_dir if the FS is already
mounted
- the fix on the mount module makes sure that mount_over_dir
is the one checked (for already mounted) if mount_dir and
mount_over_dir paramters are both used.
- added corresponding unit test cases for mount module