### PR TITLE
backup module fixes due to issues found in integration testing

### DIFF
--- a/playbooks/demo_backup_datavg.yml
+++ b/playbooks/demo_backup_datavg.yml
@@ -1,10 +1,16 @@
 ---
 - name: "Backup operations on datavg using savevg and restvg for AIX"
-  hosts: all
+  hosts: ansible-test1
+  remote_user: root
   gather_facts: no
   vars:
     type_v:                 "savevg"
     vg_name_v:              "datavg"
+    lv_name_v:              "testlv"
+    lv_size_v:              5
+    lv_type_v:              "jfs2"
+    mnt_pt_v:               "/tmp/testfs"
+    fs_type_v:              "jfs2"
     disk_name_v:            "hdisk1"
     location_v:             "/tmp/datavg_backup"
     exclude_data_v:         False
@@ -19,6 +25,40 @@
     restvg_flags_v:         "-n"                    # ignore existing MAP files
 
   tasks:
+  - name: create volume group
+    lvg:
+      state: present
+      vg_name: "{{ vg_name_v }}"
+      pvs: "{{ disk_name_v }}"
+
+  - name: create logical volume
+    lvol:
+      state: present
+      lv: "{{ lv_name_v }}"
+      lv_type: "{{ lv_type_v }}"
+      vg: "{{ vg_name_v }}"
+      size: "{{ lv_size_v }}"
+
+
+  - name: create filesystem
+    filesystem:
+      state: present
+      filesystem: "{{ mnt_pt_v }}"
+      fs_type: "{{ lv_type_v }}"
+      device: "{{ lv_name_v }}"
+      
+  - name: mount filesystem
+    mount:
+      state: mount
+      mount_dir: "{{ mnt_pt_v }}"
+
+  - name: check if file exists
+    shell: ls "{{ mnt_pt_v }}"/newfile || echo "create file"
+    register: output
+
+  - name: create files in filesystem
+    shell: touch "{{ mnt_pt_v }}"/newfile
+    when: "'create file' in output.stdout"
 
   - name: savevg to create a vg backup image
     backup:
@@ -31,9 +71,19 @@
       extend_fs: "{{ extend_fs_v }}"
       force: "{{ force_v }}"
       verbose: "{{ verbose_v }}"
+    register: results
+  - debug: var=results
+
+  - name: unmount filesystem
+    mount:
+      state: umount
+      mount_dir: "{{ mnt_pt_v }}"
 
   - name: remove the volume group
-    command: reducevg -d -f "{{ vg_name_v }}" "{{ disk_name_v }}"
+    lvg:
+      state: absent
+      vg_name: "{{ vg_name_v }}"
+      delete_lvs: yes
 
   - name: restvg to view the backup image information
     backup:
@@ -46,7 +96,7 @@
   - name: mv original vgname.data file
     command: mv "{{ data_file_orig_v }}" "{{ data_file_v }}"
 
-  - name: restvg to retore the backup image
+  - name: restvg to restore the backup image
     backup:
       action: restore
       type: "{{ type_v }}"
@@ -56,4 +106,3 @@
       exclude_data: "{{ exclude_data_v }}"
       minimize_lv_size: "{{ minimize_lv_size_v }}"
       flags: "{{ restvg_flags_v }}"
- 

--- a/playbooks/demo_backup_rootvg.yml
+++ b/playbooks/demo_backup_rootvg.yml
@@ -1,92 +1,128 @@
 ---
 - name: "Backup operations on rootvg using mksysb and alt_disk_mksysb for AIX"
-  hosts: all
-  gather_facts: no
+  hosts: ansible-test1
+  remote_user: root
+  gather_facts: True
   vars:
-    type_v:                     "mksysb"
-    volume_group_v:             "vg00"      # volume group where /ESSAI resides
-    disk_v:                     "hdisk1"    # hdisk1 is part of vg00
-    location_create_v:          "/ESSAI/rootvg_sysb"
-    restore_fs_v:               "/tmp"
-    restore_fs_size_v:          5G
-    location_restore_v:         "/tmp/rootvg_sysb"
-    verbose_v:                  True
-    #data_file_v:                "/tmp/image.data"
-    exclude_files_v:            False
-    exclude_fs_v:               ""
-    extend_fs_v:                True
-    mksysb_flags_v:             "-G"    # Excludes WPAR file systems
-    alt_disk_mksysb_flags_v:    ""
-    exclude_packing_files_v:    False
-    script_v:                   ""
-    resolv_conf_v:              ""
-    phase_v:                    "all"
-    remain_nim_client_v:        True
-    import_vg_v:                False
-    debug_v:                    False
-    bootlist_v:                 True
-
+    type:                     "mksysb"
+    location_create:          "/tmp/backupfs/rootvg_sysb"
+    exclude_fs:               ""
+    extend_fs:                True
+    exclude_files:            False
+    exclude_packing_files:    False
+    verbose:                  True
+    mksysb_flags:             "-G"    # Excludes WPAR file systems
+    force:                    True
+    #data_file:               "/tmp/image.data"
+    alt_disk_mksysb_flags:    ""
+    script:                   ""
+    resolv_conf:              ""
+    phase:                    "all"
+    remain_nim_client:        True
+    import_vg:                False
+    debug:                    False
+    bootlist:                 True
+    vg_name:                  "backupvg"
+    pv_list:                  hdisk1 hdisk2 hdisk3
+    lv_name:                  "backuplv"
+    lv_type:                  "jfs2"
+    lv_size:                  "5G"
+    fs_mnt:                   "/tmp/backupfs"
+    fs_type:                  "jfs2"
+    delete_lvs:               True
+    restore_fs:               "/tmp"
+    restore_fs_size:          "5G"
+    location_restore:         "/tmp/rootvg_sysb"
 
   tasks:
+  - name: "create volume group or backup image"
+    lvg:
+      state: present
+      vg_name: "{{ vg_name }}"
+      pvs: "{{ pv_list }}"
+
+  - name: "create logical volume for backup image"
+    lvol:
+      state: present
+      vg: "{{ vg_name }}"
+      lv: "{{ lv_name }}"
+      lv_type: "{{ lv_type }}"
+      size: "{{ lv_size }}"
+
+  - name: "create filesystem for backup image"
+    filesystem:
+      state: present
+      filesystem: "{{ fs_mnt }}"
+      fs_type: "{{ fs_type }}"
+      device: "{{ lv_name }}"
+
+  - name: "mount filesystem"
+    mount:
+      state: mount
+      mount_dir: "{{ fs_mnt }}"
 
   - name: create a mksysb image of rootvg
     backup:
       action: create
-      type: "{{ type_v }}"
-      location: "{{ location_create_v }}"
-      exclude_fs: "{{ exclude_fs_v }}"
-      exclude_files: "{{ exclude_files_v }}"
-      extend_fs: "{{ extend_fs_v }}"
-      exclude_packing_files: "{{ exclude_packing_files_v }}"
-      verbose: "{{ verbose_v }}"
-      flags: "{{ mksysb_flags_v }}"
-#    register: result
-#  - debug: var=result
+      type: "{{ type }}"
+      location: "{{ location_create }}"
+      # exclude_fs: "{{ exclude_fs }}"
+      exclude_files: "{{ exclude_files }}"
+      extend_fs: "{{ extend_fs }}"
+      exclude_packing_files: "{{ exclude_packing_files }}"
+      # verbose: "{{ verbose }}"
+      flags: "{{ mksysb_flags }}"
+      force: "{{ force }}"
+    register: result
+  - debug: var=result
 
   - name: view the mksysb image
     backup:
       action: view
-      type: "{{ type_v }}"
-      location: "{{ location_create_v }}"
-#    register: result
-#  - debug: var=result
+      type: "{{ type }}"
+      location: "{{ location_create }}"
+    register: result
+  - debug: var=result
 
-#  - name: increase filesystem to move mksysb image
-#    filesystem:
-#      filesystem: "{{ restore_fs_v }}"
-#      state: present
-#      attributes: size="{{ restore_fs_size_v }}"
+  - name: increase filesystem to move mksysb image
+    filesystem:
+      state: present
+      filesystem: "{{ restore_fs }}"
+      attributes: size="{{ restore_fs_size }}"
 
-#  - name: move mksysb image to /tmp
-#    copy:
-#      remote_src: yes
-#      src: "{{ location_create_v }}"
-#      dest: "{{ location_restore_v }}"
+  # ulimit for fsize and data must be unlimited
+  - name: move mksysb image to /tmp
+    copy:
+      remote_src: yes
+      src: "{{ location_create }}"
+      dest: "{{ location_restore }}"
 
-#  - name: unmount the filesystem
-#    filesystem:
-#      state: absent
-#      filesystem: "{{ restore_fs_v }}"
-#      rm_mount_point: yes
+  - name: "unmount the filesystem"
+    mount:
+      state: umount
+      mount_dir: "{{ fs_mnt }}"
 
-#  - name: remove volume group prior to install mksysb
-  # reducevg -d vg00 hdisk1
+  - name: "delete volume group"
+    lvg:
+      state: absent
+      vg_name: "{{ vg_name }}"
+      delete_lvs: "{{ delete_lvs }}"
 
-#  - name: install the mksysb image to disk
-#    backup:
-#      action: restore
-#      type: "{{ type_v }}"
-#      location: "{{ location_restore_v }}"
-#      data_file: "{{ data_file_v }}"
-#      disk: "{{ disk_v }}"
-#      script: "{{ script_v }}"
-#      resolv_conf: "{{ resolv_conf_v }}"
-#      phase: "{{ phase_v }}"
-#      remain_nim_client: "{{ remain_nim_client_v }}"
-#      import_vg: "{{ import_vg_v }}"
-#      debug: "{{ debug_v }}"
-#      bootlist: "{{ bootlist_v }}"
-#      verbose: "{{ verbose_v }}"
-#      flags: "{{ alt_disk_mksysb_flags_v }}"
-#    register: result
-#  - debug: var=result
+  - name: install the mksysb image to disk
+    backup:
+      action: restore
+      type: "{{ type }}"
+      location: "{{ location_restore }}"
+      # data_file: "{{ data_file }}"
+      disk: "{{ pv_list }}"
+      # script: "{{ script }}"
+      # resolv_conf: "{{ resolv_conf }}"
+      phase: "{{ phase }}"
+      remain_nim_client: "{{ remain_nim_client }}"
+      import_vg: "{{ import_vg }}"
+      debug: "{{ debug }}"
+      bootlist: "{{ bootlist }}"
+      # verbose: "{{ verbose }}"
+      # flags: "{{ alt_disk_mksysb_flags }}"
+    register: result
+  - debug: var=result

--- a/plugins/modules/backup.py
+++ b/plugins/modules/backup.py
@@ -393,14 +393,15 @@ def mksysb(module, params):
         pattern = r"0512-054"
         found = re.search(pattern, results['stdout'])
         if found:
-            module.log('Backup file "{0}" does not exist or empty proceed to savevg.'.format(params['location']))
+            module.log('Backup file "{0}" does not exist or empty proceed to mksysb.'.format(params['location']))
         elif rc == 0:
             vg_name = [s for s in results['stdout'].splitlines() if "VOLUME GROUP:" in s][0].split(':')[1].strip()
             if vg_name == vg:
-                results['msg'] = 'Backup images for {0} already exists.'.format(vg)
+                results['msg'] = 'Backup images for {0} already exists. User force to overwrite'.format(vg)
                 return 0
             else:
-                results['msg'] = 'Backup images already exists for {0} volume group. Use force to overwrite.'.format(vg_name)
+                results['msg'] = 'Backup images already exists for {0} volume group '.format(vg_name)
+                results['msg'] += 'on the specified location, {0}. Use force to overwrite.'.format(params['location'])
                 return 1
         else:
             results['msg'] = 'Cannot check {0} backup image existence.'.format(vg)
@@ -591,10 +592,11 @@ def savevg(module, params, vg):
         elif rc == 0:
             vg_name = [s for s in results['stdout'].splitlines() if "VOLUME GROUP:" in s][0].split(':')[1].strip()
             if vg_name == vg:
-                results['msg'] = 'Backup images for {0} already exists.'.format(vg)
+                results['msg'] = 'Backup images for {0} already exists. Use force to overwrite'.format(vg)
                 return 0
             else:
-                results['msg'] = 'Backup images already exists for {0} volume group. Use force to overwrite.'.format(vg_name)
+                results['msg'] = 'Backup images already exists for {0} volume group '.format(vg_name)
+                results['msg'] += 'on the specified location, {0}. Use force to overwrite.'.format(params['location'])
                 return 1
         else:
             results['msg'] = 'Cannot check {0} backup image existence.'.format(vg)

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -32,15 +32,5 @@ plugins/modules/reboot.py validate-modules:module-invalid-version-added
 plugins/modules/smtctl.py validate-modules:module-invalid-version-added
 plugins/modules/suma.py validate-modules:module-invalid-version-added
 plugins/modules/user.py validate-modules:module-invalid-version-added
-plugins/modules/alt_disk.py pylint:consider-using-dict-items
-plugins/modules/nim_updateios.py pylint:consider-using-dict-items
-plugins/modules/nim_vios_alt_disk.py pylint:consider-using-dict-items
-plugins/modules/nim_vios_hc.py pylint:consider-using-dict-items
-plugins/modules/nim_viosupgrade.py pylint:consider-using-dict-items
-plugins/modules/flrtvc.py pylint:consider-using-with
-plugins/modules/nim_flrtvc.py pylint:consider-using-with
-plugins/modules/nim_suma.py pylint:consider-using-with
-plugins/modules/nim_viosupgrade.py pylint:consider-using-with
-plugins/modules/suma.py pylint:consider-using-with
 plugins/modules/lvm_facts.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/lpar_facts.py validate-modules:invalid-ansiblemodule-schema


### PR DESCRIPTION
- updated examples for clarity and typos
- update 'extend_fs' parameter description for
more clarity
- fix message typos
- issue found when 'state=create' and 'type==savevg'
and 'force' is not set leading to checking if backup
file already exists, however if backup file specified
by 'location' does not exist it will report an error
and fail the task instead of proceeding in creating a
backup image of the user volume group (savevg) as intended
- creating rootvg backup image (mksysb) is now idempotent.
if a backup image is already there in the specified
location, it will check if it is a rootvg image. if it
is a rootvg image, then do nothing and report backup
image already exists, else fail task
- force option for mksysb is now available, to overwrite
a backup image on the specified location if any
- fix alt_disk_mksysb parsing of 'disk' parameter. issue
found when given a list of strings in ["..", "..", ...]
format
- for 'view' action, make sure to use the appropriate
command for each 'type'. lsmksysb routine for 'mksysb'
and restvg_view routine for 'savevg'